### PR TITLE
docs(getting-started&readme): add sass include paths instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To do this, include the `/node_modules` directory into [include paths](https://g
 
 ### Include Paths in Angular 6+
 In `angular.json` file, make sure the `node_modules/` is listed as the `includePaths` under the `build.options` configuration to enable the Sass compiler run properly.
-```json
+```
 {
   "build": {
     ...,

--- a/README.md
+++ b/README.md
@@ -11,13 +11,33 @@ $ npm install @amar-ui-web/core
 $ yarn add @amar-ui-web/core
 ```
 
+## Resolve Sass Include Paths
+Upon installation, `@amar-ui-web/core` and other `@amar-ui-web/*` package dependencies will be accessible from inside your project's `node_modules` directory, but you **cannot access them directly just yet**. You'll need to resolve `/node_modules` directory path first since `@amar-ui-web/core` uses *absolute import* to depend on its sub-packages using Sass' `@import`.
+
+To do this, include the `/node_modules` directory into [include paths](https://github.com/sass/node-sass#includepaths) property in your preferred bundler (we recommend webpack). Otherwise, follow the below guidelines for more *framework-specific guides* to setup this part properly.
+
+### Include Paths in Angular 6+
+In `angular.json` file, make sure the `node_modules/` is listed as the `includePaths` under the `build.options` configuration to enable the Sass compiler run properly.
+```json
+{
+  "build": {
+    ...,
+    "options": {
+      ...,
+      "styles": [
+        "src/styles.scss"
+      ], 
+      // add this line, just below "styles"
+      "stylePreprocessorOptions": {
+        "includePaths": ["node_modules/"]
+      },
+    }
+  }
+}
+```
+
 ## Usage
-
-Upon installation, `@amar-ui-web/core` and other `@amar-ui-web/*` package dependencies will be accessible from inside your project's `node_modules` directory, but you cannot access them directly just yet. You'll need to resolve `/node_modules` directory path first since `@amar-ui-web/core` uses absolute import to depend on its sub-packages using Sass' `@import`.
-
-To do this, include the `/node_modules` directory into [include paths](https://github.com/sass/node-sass#includepaths) property in your preferred bundler (we recommend webpack).
-
-Once you're done, you should then be able import the package like this:
+Once you're done with the include paths, you should then be able import the package like this:
 
 ```scss
 @import '@amar-ui-web/core/index.scss';

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ In `angular.json` file, make sure the `node_modules/` is listed as the `includeP
   }
 }
 ```
+***Note***: *Don't forget to restart the `ng serve` after changing the `angular.json` file. Otherwise, the new changes will not be applied.*
 
 ## Usage
 Once you're done with the include paths, you should then be able import the package like this:

--- a/packages/docs/src/docs/introduction/getting-started.mdx
+++ b/packages/docs/src/docs/introduction/getting-started.mdx
@@ -6,7 +6,7 @@ description: 'Quick start guide on how to get started with Amar UI Web.'
 
 ## Installation
 
-Amar UI Web can be installed by using package managers such as yarn and npm.
+Amar UI Web can be installed by using **package managers** such as `yarn` and `npm`.
 
 ```shell
 # Using npm
@@ -16,10 +16,38 @@ npm install @amar-ui-web/core
 yarn add @amar-ui-web/core
 ```
 
-Once installed in your project, you can then proceed to import the `index.scss` of
+## Resolve Sass Include Paths
+Upon installation, `@amar-ui-web/core` and other `@amar-ui-web/*` package dependencies will be accessible from inside your project's `node_modules` directory, but you **cannot access them directly just yet**. You'll need to resolve `/node_modules` directory path first since `@amar-ui-web/core` uses *absolute import* to depend on its sub-packages using Sass' `@import`.
+
+To do this, include the `/node_modules` directory into [include paths](https://github.com/sass/node-sass#includepaths) property in your preferred bundler (we recommend webpack). Otherwise, follow the below guidelines for more *framework-specific guides* to setup this part properly.
+
+### Include Paths in Angular 6+
+In `angular.json` file, make sure the `node_modules/` is listed as the `includePaths` under the `build.options` configuration to enable the Sass compiler run properly.
+```json
+{
+  "build": {
+    ...,
+    "options": {
+      ...,
+      "styles": [
+        "src/styles.scss"
+      ], 
+      // add this line, just below "styles"
+      "stylePreprocessorOptions": {
+        "includePaths": ["node_modules/"]
+      },
+    }
+  }
+}
+```
+
+## Usage
+Once you're done with the include paths, you can then proceed to import the `index.scss` of
 `@amar-ui-web/core` into your project's style entrypoint.
 
 ```scss
 // For example, styles.scss is our entrypoint.
 @import '@amar-ui-web/core/index.scss';
 ```
+
+You're done! Amar UI Web is now configured to be used in your application.

--- a/packages/docs/src/docs/introduction/getting-started.mdx
+++ b/packages/docs/src/docs/introduction/getting-started.mdx
@@ -40,6 +40,7 @@ In `angular.json` file, make sure the `node_modules/` is listed as the `includeP
   }
 }
 ```
+***Note***: *Don't forget to restart the `ng serve` after changing the `angular.json` file. Otherwise, the new changes will not be applied.*
 
 ## Usage
 Once you're done with the include paths, you can then proceed to import the `index.scss` of


### PR DESCRIPTION
# Background
Upon installing `npm i @amar-ui-web/core`, importing the main styling `@import  '@amar-ui-web/core/index.scss'`, and running the app in Angular 8, the following error occurs:
![image](https://user-images.githubusercontent.com/11956622/80961007-35c88a00-8e34-11ea-9bb9-7e313b9e9a62.png)
Apparently, this is due to the Angular App cannot resolve the *absolute import path*, which is being used in `./node_modules/@amar-ui-web` itself.

# PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

# What is the current behavior?
Missing documentation on how to resolve `sass` import path issues (that specifically occurred when developing using Angular 8).

# What is the new behavior?
Documented a new behavior for **Include Path in Angular 6+** in the `README.md` file and `Getting Started` section.

# Does this PR introduce a breaking change?
- [ ] Yes
- [x] No