### PR TITLE
docs(button): fix typo on Themes code block

### DIFF
--- a/packages/docs/src/docs/components/button.mdx
+++ b/packages/docs/src/docs/components/button.mdx
@@ -24,7 +24,7 @@ To apply a themed button, simply append the `Button--<theme>` after `Button` cla
 ```html preview=true
 <button class="Button Button--primary">Primary</button>
 <button class="Button Button--secondary">Secondary</button>
-<button class="Button Button--success">Warning</button>
+<button class="Button Button--success">Success</button>
 <button class="Button Button--warning">Warning</button>
 <button class="Button Button--danger">Danger</button>
 <button class="Button Button--dark">Dark</button>


### PR DESCRIPTION
## Linked Issue
#7 

