### PR TITLE
refactor: adjust Text color and add new shade 100

### DIFF
--- a/docs/src/docs/foundations/color-system.mdx
+++ b/docs/src/docs/foundations/color-system.mdx
@@ -42,6 +42,12 @@ description: 'The unified color language of Amar UI.'
       <code>$amb-neutral-30</code>
     </div>
   </div>
+  <div className="Grid Grid-3">
+    <div className="BgColor-darkest Flex Flex-column JustifyContent-center AlignItems-center Padding">
+      <p className="Typography-regular16 FontWeight-semibold">Darkest</p>
+      <code>$amb-neutral-100</code>
+    </div>
+  </div>
 </div>
 
 #### UI colors
@@ -160,6 +166,7 @@ $amb-color-theme-map: map-merge(
     'lighter': $amb-neutral-10,
     'dark': $amb-neutral-80,
     'darker': $amb-neutral-90,
+    'darkest': $amb-neutral-100,
   ),
   $amb-color-theme-map
 );

--- a/docs/src/docs/utilities/color.mdx
+++ b/docs/src/docs/utilities/color.mdx
@@ -17,6 +17,7 @@ Use `.Color-<theme>` class to change the **text color** of an element.
 <div class="Color-info Padding-small">Info Color</div>
 <div class="Color-light Padding-small">Light Color</div>
 <div class="Color-dark Padding-small">Dark Color</div>
+<div class="Color-darkest Padding-small">Darkest Color</div>
 ```
 
 ## Background color
@@ -37,7 +38,7 @@ Use `.BgColor-<theme>` class to change the **background color** of an element.
 ## Color shades
 
 To use a different shade of a color theme for text or background color in an element, simply add
-`*-<shadeLevel>`. By default, you can choose shade level ranging from 10 to 90.
+`*-<shadeLevel>`. By default, you can choose shade level ranging from 10 to 100.
 
 #### Text color shades
 
@@ -52,6 +53,7 @@ To use a different shade of a color theme for text or background color in an ele
 <div class="Color-primary-70 Padding-small">Primary 70</div>
 <div class="Color-primary-80 Padding-small">Primary 80</div>
 <div class="Color-primary-90 Padding-small">Primary 90</div>
+<div class="Color-primary-100 Padding-small">Primary 100</div>
 ```
 
 #### Background color shades

--- a/library/color/scss/_color-palletes.scss
+++ b/library/color/scss/_color-palletes.scss
@@ -10,3 +10,6 @@ $gray: #cdd0d6;
 
 $black: #000000;
 $white: #ffffff;
+
+$gray-dark: #64686E;
+$gray-darker: #25282B;

--- a/library/color/scss/_color-palletes.scss
+++ b/library/color/scss/_color-palletes.scss
@@ -7,9 +7,8 @@ $green: #08b800;
 $red: #dd1717;
 $yellow: #ffd500;
 $gray: #cdd0d6;
+$gray-dark: #64686e;
+$gray-darker: #25282b;
 
 $black: #000000;
 $white: #ffffff;
-
-$gray-dark: #64686E;
-$gray-darker: #25282B;

--- a/library/color/scss/_variables.scss
+++ b/library/color/scss/_variables.scss
@@ -20,8 +20,9 @@ $amb-neutral-40: tint($amb-neutral, 20%);
 $amb-neutral-50: $amb-neutral;
 $amb-neutral-60: shade($amb-neutral, 20%);
 $amb-neutral-70: shade($amb-neutral, 40%);
-$amb-neutral-80: shade($amb-neutral, 60%);
+$amb-neutral-80: $gray-dark;
 $amb-neutral-90: shade($amb-neutral, 80%);
+$amb-neutral-100: $gray-darker;
 
 /// Map variables for color themes.
 ///
@@ -40,6 +41,7 @@ $amb-color-theme-map: map-merge(
     'lighter': $amb-neutral-10,
     'dark': $amb-neutral-80,
     'darker': $amb-neutral-90,
+    'darkest': $amb-neutral-100,
   ),
   $amb-color-theme-map
 );


### PR DESCRIPTION
### **Description**

Adjust text color shade 80 and add for shade 100, base on  [Design system changeLog](https://zeroheight.com/19c7d85e4/p/480bdf-changelog/b/56d6c8)

### **PR Type**

- [x] Refactoring
- [x]  Code style update (formatting, local variables)

### **Changes**

- Change `$amb-neutral-80` to color `#64686E`
- Add `$amb-neutral-100 `with color `#25282B`
- Add new variable `$gray-dark` and `$gray-darker` in `_color-pallete`
- If I use function `shade()` or `tint()` for create hex `#64686E` and  `#25282B` it's not found the match color, because of that I create new variable in `color-pallete`

### **User Interface**

- In Color System Amar UI

![Screenshot_12](https://user-images.githubusercontent.com/22863200/160314338-e41c57c1-6e9a-4c60-8fd2-5f7354be0fbb.png)

![Screenshot_14](https://user-images.githubusercontent.com/22863200/160314344-0cd42113-ff94-4067-8f8c-bd13f3307e01.png)

- In Color Utilities Amar UI

![Screenshot_15](https://user-images.githubusercontent.com/22863200/160314346-f0fabacb-744e-4732-982d-88834b46aa63.png)

![Screenshot_16](https://user-images.githubusercontent.com/22863200/160314348-5e404c00-bada-47ad-815d-cae2f1d728b6.png)

![Screenshot_17](https://user-images.githubusercontent.com/22863200/160314351-d060978d-434c-4d22-96f0-82c120441ef8.png)

- In Tunaiku web

![Screenshot_18](https://user-images.githubusercontent.com/22863200/160314354-572d77d6-58b2-4d49-b467-4961dd725af0.png)

![Screenshot_19](https://user-images.githubusercontent.com/22863200/160314359-cbf6f8a2-90d3-4532-94fd-295cb56d7b12.png)
