### PR TITLE
Adjust card border-radius and shadow

### DIFF
--- a/library/card/scss/_mixins.scss
+++ b/library/card/scss/_mixins.scss
@@ -35,7 +35,6 @@
 
 @mixin amb-create-card-modifiers() {
   &--elevated {
-    // @include amb-create-elevation($level: 3, $opacity: 0.15);  // TODO: ganti jadi box-shadow sesuai fixing zeroheight
     box-shadow: $amb-card-elevation;
   }
 

--- a/library/card/scss/_mixins.scss
+++ b/library/card/scss/_mixins.scss
@@ -35,7 +35,8 @@
 
 @mixin amb-create-card-modifiers() {
   &--elevated {
-    @include amb-create-elevation($level: 3, $opacity: 0.1);
+    // @include amb-create-elevation($level: 3, $opacity: 0.15);  // TODO: ganti jadi box-shadow sesuai fixing zeroheight
+    box-shadow: $amb-card-elevation;
   }
 
   &--borderless {

--- a/library/card/scss/_variables.scss
+++ b/library/card/scss/_variables.scss
@@ -10,4 +10,4 @@ $amb-card-border-style: solid;
 $amb-card-border-width: 1px;
 $amb-card-border-color: amb-color-theme('neutral', 30);
 $amb-card-border-radius: 12px;
-$amb-card-elevation: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+$amb-card-elevation: 0 3px 12px 0 rgba(0, 0, 0 , 0.15);

--- a/library/card/scss/_variables.scss
+++ b/library/card/scss/_variables.scss
@@ -9,4 +9,5 @@ $amb-card-fg-color: amb-color-contrast($amb-card-bg-color);
 $amb-card-border-style: solid;
 $amb-card-border-width: 1px;
 $amb-card-border-color: amb-color-theme('neutral', 30);
-$amb-card-border-radius: amb-border-radius('xlarge');
+$amb-card-border-radius: 12px;
+$amb-card-elevation: rgba(0, 0, 0, 0.24) 0px 3px 8px;


### PR DESCRIPTION
### **Description**
Adjust the border-radius value to 12px for .Card class.
Create a new variable for 15 of Alpha shadow (there is currently no detail about the exact value of 15 in CSS, need to ask UI/UX team first). (untuk sekarang kita treat value 15 ini sebagai opacity 0.15)

### **Changes**

- add new variable `$amb-card-border-radius` and set value to `12px`
- add new variable `$amb-card-elevation` and set value to `0 3px 12px 0 rgba(0, 0, 0 , 0.15)`
- change value `border-radius` in mixins card
- change value `box-shadow` with temporary value because the fix value is not declared from UI/UX

### **User Interface**
**In Amar UI**
![Screenshot_2](https://user-images.githubusercontent.com/22863200/168262058-9af4254e-6497-4908-89aa-3a9e9912cd8a.png)

**In Msite**
![Screenshot_1](https://user-images.githubusercontent.com/22863200/168262144-89c002ef-6aeb-4af0-9380-0fc1b12fbf65.png)


